### PR TITLE
#48 StoresテーブルとUsersテーブルを関連付けする

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -10,7 +10,7 @@ class StoresController < ApplicationController
   end
 
   def create
-    @store = Store.new(stores_params)
+    @store = current_user.stores.new(stores_params)
     @store.save
     redirect_to stores_path
   end
@@ -27,7 +27,7 @@ class StoresController < ApplicationController
 
   private
    def stores_params
-      params.require(:store).permit(:store_name,:user_id)
+      params.require(:store).permit(:store_name, :user_id)
    end
 
    def admin_user

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -26,7 +26,7 @@ class StoresController < ApplicationController
 
   private
    def stores_params
-      params.require(:store).permit(:store_name)
+      params.require(:store).permit(:store_name,:user_id)
    end
 
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,3 +1,4 @@
 class Store < ActiveRecord::Base
   has_many :studios
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_many :reservations
+  has_many :stores
   validates :name, presence: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/db/migrate/20180708063744_add_user_id_to_stores.rb
+++ b/db/migrate/20180708063744_add_user_id_to_stores.rb
@@ -1,0 +1,5 @@
+class AddUserIdToStores < ActiveRecord::Migration
+  def change
+    add_column :stores, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180708041550) do
+ActiveRecord::Schema.define(version: 20180708063744) do
 
   create_table "reservations", force: true do |t|
     t.integer  "place",      limit: 255
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20180708041550) do
     t.string   "store_name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "user_id"
   end
 
   create_table "studios", force: true do |t|


### PR DESCRIPTION
Storesテーブルにuser_idのカラムを追加し、モデルにてUsersテーブルと関連付けを行いました。
またadminユーザーにてログインし店舗登録した際はuser_idにログインユーザーのIDが入るように
Storesコントローラーのnewアクションを修正しました。

まだ店舗登録へのリンクを実装していないので登録する際はログイン後にstores/newのurlを直接叩く必要があります。
この部分は別のブランチで開発予定です。

