### PR TITLE
#55 店舗操作画面修正

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,5 +1,5 @@
 class StoresController < ApplicationController
-  before_action :admin_user
+  before_action :authenticate_user!, :admin_user
 
   def index
     @stores = Store.all

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -17,4 +17,8 @@ class StudiosController < ApplicationController
       params.require(:studio).permit(:studio_name, :store_id)
     end
 
+    def admin_user
+       redirect_to(root_url) unless current_user.admin?
+    end
+
 end

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -1,4 +1,6 @@
 class StudiosController < ApplicationController
+  before_action :authenticate_user!, :admin_user
+
   def new
     @studio = Studio.new
     @store_id = params[:store_id]


### PR DESCRIPTION
サインアウトしている状態で店舗の一覧、詳細、新規登録、削除をするとエラーとなるのを解消しました。
StoreコントローラーとStudioコントローラーへのアクセスをsign inしている、かつadminユーザーでない場合は弾くように実装しました。