### PR TITLE
#20 ユーザー編集画面のレイアウト修正とリンク追加

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,4 +9,8 @@ class RegistrationsController < Devise::RegistrationsController
       def sign_up_params
         params.require(:user).permit(:name, :email, :password, :password_confirmation, :admin)
       end
+
+      def account_update_params
+        params.require(:user).permit(:name, :email, :password, :password_confirmation, :current_password)
+      end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, 'Edit') %>
-<h1 id="my-page">Edit</h1>
+<% provide(:title, 'ユーザー情報編集画面') %>
+<h1 id="my-page">ユーザー情報編集画面</h1>
 <%# TODO: idをclassに修正する %>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
@@ -37,7 +37,7 @@
       </div>
 
       <div class="form-group">
-        <%= f.submit "Update", class: "btn btn-default" %>
+        <%= f.submit "変更", class: "btn btn-default" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,39 +1,43 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<% provide(:title, 'Edit') %>
+<h1 id="my-page">Edit</h1>
+<%# TODO: idをclassに修正する %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+<div id="sign-up">
+<%# TODO: idをclassに修正する %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
-  </div>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name, autofocus: true %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true %>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+
+    <div class="field">
+      <%= f.label :変更後パスワード %><br />
+      <%= f.password_field :password, autocomplete: "off" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :パスワード確認 %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :現在のパスワード %><br />
+      <%= f.password_field :current_password, autocomplete: "off" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Update" %>
+    </div>
   <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,42 +2,43 @@
 <h1 id="my-page">Edit</h1>
 <%# TODO: idをclassに修正する %>
 
-<div id="sign-up">
-<%# TODO: idをclassに修正する %>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
+  <div class="row">
+    <div class="col-md-6 col-md-offset-3">
+      <%= render 'shared/error_messages', object: f.object %>
 
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true %>
+      <div class="form-group">
+        <%= f.label :name %><br />
+        <%= f.text_field :name, autofocus: true, class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, class: "form-control" %>
+      </div>
+
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
+
+      <div class="form-group">
+        <%= f.label :変更後パスワード %><br />
+        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :パスワード確認 %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :現在のパスワード %><br />
+        <%= f.password_field :current_password, autocomplete: "off", class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.submit "Update", class: "btn btn-default" %>
+      </div>
     </div>
-
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true %>
-    </div>
-
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-    <% end %>
-
-    <div class="field">
-      <%= f.label :変更後パスワード %><br />
-      <%= f.password_field :password, autocomplete: "off" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :パスワード確認 %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "off" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :現在のパスワード %><br />
-      <%= f.password_field :current_password, autocomplete: "off" %>
-    </div>
-
-    <div class="actions">
-      <%= f.submit "Update" %>
-    </div>
+  </div>
   <% end %>
-</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,12 +20,12 @@
             <%= link_to "Sign out", destroy_user_session_path, method: "delete" %>
           </li>
           <li>
-            <%= link_to "Edit", edit_user_registration_path %>
+            <%= link_to "ユーザー情報編集", edit_user_registration_path %>
           </li>
        <% else %>
           <li class="<%= 'active' if current_page?(root_path) %>">
             <%= link_to "Home", root_path, class: "navbar-brand" %>
-          </il>
+          </li>
           <li class="<%= 'active' if current_page?(new_user_registration_path) %>">
             <%= link_to "Sign up", new_user_registration_path %>
           </li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,9 +19,12 @@
           <li>
             <%= link_to "Sign out", destroy_user_session_path, method: "delete" %>
           </li>
+          <li>
+            <%= link_to "Edit", edit_user_registration_path %>
+          </li>
        <% else %>
           <li class="<%= 'active' if current_page?(root_path) %>">
-            <%= link_to "Home", root_path, class:"navbar-brand" %>
+            <%= link_to "Home", root_path, class: "navbar-brand" %>
           </il>
           <li class="<%= 'active' if current_page?(new_user_registration_path) %>">
             <%= link_to "Sign up", new_user_registration_path %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,11 +2,11 @@
   <div id="error_explanation">
     <div class="alert alert-danger">
       The form contains <%= pluralize(object.errors.count, "error") %>.
+      <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <li>* <%= msg %></li>
+      <% end %>
+      </ul>
     </div>
-    <ul>
-    <% object.errors.full_messages.each do |msg| %>
-      <li>* <%= msg %></li>
-    <% end %>
-    </ul>
   </div>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,10 @@
 <% if object.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(object.errors.count, "error") %>.
-      <ul>
+      <%= object.errors.count %>件のエラーがあります。
       <% object.errors.full_messages.each do |msg| %>
-        <li>* <%= msg %></li>
+        <li><%= msg %></li>
       <% end %>
-      </ul>
     </div>
   </div>
 <% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -72,6 +72,7 @@ ja:
         password: パスワード
         password_confirmation: パスワード確認
         email: メールアドレス
+        current_password: 現在のパスワード
 
     ja:
   date:


### PR DESCRIPTION
deviseの機能を利用しユーザー情報の編集画面を作成した。
deviseそのままだと名前の変更フォームが無いため名前変更フォームを追加。
それに伴いStrong parameterにもnameを追加しました。
エラーメッセージの形式はSign upの箇所と同様のパーシャルを適用し実装しました。

また、ヘッダーに編集画面へのリンクを作成しました。

