### PR TITLE
#93 【予約編集画面】画面表示したときにエラー

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -23,6 +23,7 @@ class ReservationsController < ApplicationController
 
   def edit
     @reservation = Reservation.find(params[:id])
+    @studio = Studio.find(@reservation.studio_id)
     @store = Store.find(@reservation.store_id)
     @studios = Studio.where(store_id: @store)
     @frame = Reservation.new.frame_list


### PR DESCRIPTION
https://github.com/ecoyamas/msrs_app/issues/93

【エラーの原因と修正】
エラー事象としましては、予約編集画面のスタジオ選択フォームでプルダウンにデフォルトで予約済みのスタジオが選択される処理でエラーが発生しました。

原因はReservationsコントローラーのeditアクションに@studioの記載が存在しないため、:selected => @studio.idの箇所でNo methodエラーが発生しておりました。

修正内容としましては、Reservationsコントローラーのeditアクションに@studioの記載を追加し、予約済みのスタジオ情報を取得しエラーを解消しました。